### PR TITLE
Update K8s deploys to Postgres 17.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 # Generated YAML from deploy scripts. May contain emails, names, etc.
 *.generated.yaml
 .minio-data
+
+# Postgres dumps from deploys/Makefile's dump_backend_postgres/upgrade_backend_postgres. Contain
+# real user data.
+/deploys/backups/

--- a/deploys/Makefile
+++ b/deploys/Makefile
@@ -13,6 +13,13 @@ TARGET_NAMESPACE ?= jonline
 
 TEST_GRPC_TARGET ?= $(shell $(MAKE) get_backend_external_ip):27707
 
+# Used by the Postgres dump/restore targets below (e.g. during upgrade_backend_postgres).
+PG_UPGRADE_LOCAL_PORT ?= 15432
+PG_BACKUP_DIR ?= backups
+PG_PASSWORD ?= secure_password1
+# Replica count restored by start_backend after a stop_backend/start_backend maintenance window.
+BACKEND_REPLICAS ?= 2
+
 # K8s server deployment targets
 # Use "internal" when deploying with a separate load balancer, and 
 # use deploy_be_link_lb_service_account to link the load balancer to the
@@ -49,6 +56,16 @@ monitor_backend_rollout:
 
 restart_backend:
 	kubectl rollout restart deployment jonline -n $(NAMESPACE)
+
+# Scales the app to 0 so it can't write to Postgres during maintenance (e.g. upgrade_backend_postgres).
+stop_backend:
+	kubectl scale deployment jonline --replicas=0 -n $(NAMESPACE)
+	kubectl wait --for=delete pod -l app=jonline -n $(NAMESPACE) --timeout=60s || true
+
+# Restores the app to BACKEND_REPLICAS after a stop_backend maintenance window.
+start_backend:
+	kubectl scale deployment jonline --replicas=$(BACKEND_REPLICAS) -n $(NAMESPACE)
+	$(MAKE) monitor_backend_rollout
 
 get_backend_external_ip:
 # Suppress echoing this so 'make get_backend_external_ip` is easily composable. 
@@ -94,6 +111,7 @@ deploy_ensure_storageclass_retain:
 
 # K8s DB deployment targets (optional if using managed DB)
 create_backend_postgres: deploy_ensure_namespace deploy_ensure_storageclass_retain
+	kubectl create -f k8s/k8s-postgres-pvc-$(K8S_PROVIDER).yaml --save-config -n $(NAMESPACE)
 	kubectl create -f k8s/k8s-postgres-$(K8S_PROVIDER).yaml --save-config -n $(NAMESPACE)
 
 update_backend_postgres:
@@ -102,8 +120,102 @@ update_backend_postgres:
 delete_backend_postgres:
 	- kubectl delete -f k8s/k8s-postgres-$(K8S_PROVIDER).yaml -n $(NAMESPACE)
 
+# Separate from delete_backend_postgres since it's rarely wanted: releases the PVC (data itself
+# is safe either way, since the PV's reclaimPolicy is Retain -- see storageclass-retain-*.yaml --
+# but this makes the volume unbound/orphaned from any PVC until manually reclaimed).
+delete_backend_postgres_pvc:
+	- kubectl delete -f k8s/k8s-postgres-pvc-$(K8S_PROVIDER).yaml -n $(NAMESPACE)
+
 restart_backend_postgres:
 	kubectl rollout restart statefulset jonline-postgres -n $(NAMESPACE)
+
+# Scales Postgres to 0. Data is untouched (PV reclaimPolicy is Retain) -- this just stops the pod.
+# Run dump_backend_postgres (or upgrade_backend_postgres, which does this for you) BEFORE this,
+# since it needs Postgres running to connect to.
+stop_backend_postgres:
+	kubectl scale statefulset jonline-postgres --replicas=0 -n $(NAMESPACE)
+	kubectl wait --for=delete pod/jonline-postgres-0 -n $(NAMESPACE) --timeout=60s || true
+
+wait_backend_postgres_ready:
+	kubectl wait --for=condition=ready pod/jonline-postgres-0 -n $(NAMESPACE) --timeout=2m
+
+# Dumps the `jonline` database (schema + data) from the currently-running jonline-postgres-0 pod
+# to a local file, via a temporary port-forward. Uses the local pg_dump (works against older *or*
+# newer servers), so it doubles as a general-purpose backup target and as the first step of
+# upgrade_backend_postgres. Override the output path with DUMP_FILE=path/to/file.sql.
+DUMP_FILE ?= $(PG_BACKUP_DIR)/$(NAMESPACE)-$(shell date +%Y%m%d%H%M%S).sql
+dump_backend_postgres:
+	@mkdir -p $(PG_BACKUP_DIR)
+	rm -f /tmp/pgpf-$(NAMESPACE).log; \
+	kubectl port-forward -n $(NAMESPACE) jonline-postgres-0 $(PG_UPGRADE_LOCAL_PORT):5432 >/tmp/pgpf-$(NAMESPACE).log 2>&1 & \
+	echo $$! > /tmp/pgpf-$(NAMESPACE).pid; \
+	for i in 1 2 3 4 5 6 7 8 9 10; do grep -q "Forwarding from" /tmp/pgpf-$(NAMESPACE).log 2>/dev/null && break; sleep 1; done; \
+	if ! grep -q "Forwarding from" /tmp/pgpf-$(NAMESPACE).log 2>/dev/null; then \
+		echo "ERROR: port-forward to $(NAMESPACE)/jonline-postgres-0 on port $(PG_UPGRADE_LOCAL_PORT) never came up (port may already be in use by another tunnel -- check /tmp/pgpf-$(NAMESPACE).log, or override PG_UPGRADE_LOCAL_PORT)" >&2; \
+		cat /tmp/pgpf-$(NAMESPACE).log >&2; \
+		kill $$(cat /tmp/pgpf-$(NAMESPACE).pid) 2>/dev/null; \
+		rm -f /tmp/pgpf-$(NAMESPACE).pid; \
+		exit 1; \
+	fi; \
+	PGPASSWORD=$(PG_PASSWORD) pg_dump -h localhost -p $(PG_UPGRADE_LOCAL_PORT) -U admin -d jonline --clean --if-exists -f $(DUMP_FILE); \
+	DUMP_STATUS=$$?; \
+	kill $$(cat /tmp/pgpf-$(NAMESPACE).pid) 2>/dev/null; \
+	rm -f /tmp/pgpf-$(NAMESPACE).pid; \
+	exit $$DUMP_STATUS
+
+# Restores a dump produced by dump_backend_postgres into the currently-running jonline-postgres-0
+# pod (must already have an empty/initialized `jonline` database -- i.e. run this after
+# update_backend_postgres has brought up the new version). Usage: make restore_backend_postgres
+# DUMP_FILE=backups/foo.sql
+# Retries once on failure -- the dump's --clean --if-exists means a full re-run is idempotent even
+# if a prior attempt got partway through (e.g. kubectl port-forward's SPDY tunnel dropping mid-COPY
+# under a large transfer, which happens occasionally and isn't a sign of real DB corruption).
+restore_backend_postgres:
+	@test -n "$(DUMP_FILE)" || (echo "Usage: make restore_backend_postgres DUMP_FILE=path/to/dump.sql NAMESPACE=..." >&2 && exit 1)
+	for attempt in 1 2; do \
+		rm -f /tmp/pgpf-$(NAMESPACE).log; \
+		kubectl port-forward -n $(NAMESPACE) jonline-postgres-0 $(PG_UPGRADE_LOCAL_PORT):5432 >/tmp/pgpf-$(NAMESPACE).log 2>&1 & \
+		echo $$! > /tmp/pgpf-$(NAMESPACE).pid; \
+		for i in 1 2 3 4 5 6 7 8 9 10; do grep -q "Forwarding from" /tmp/pgpf-$(NAMESPACE).log 2>/dev/null && break; sleep 1; done; \
+		if ! grep -q "Forwarding from" /tmp/pgpf-$(NAMESPACE).log 2>/dev/null; then \
+			echo "ERROR: port-forward to $(NAMESPACE)/jonline-postgres-0 on port $(PG_UPGRADE_LOCAL_PORT) never came up (port may already be in use by another tunnel -- check /tmp/pgpf-$(NAMESPACE).log, or override PG_UPGRADE_LOCAL_PORT)" >&2; \
+			cat /tmp/pgpf-$(NAMESPACE).log >&2; \
+			kill $$(cat /tmp/pgpf-$(NAMESPACE).pid) 2>/dev/null; \
+			rm -f /tmp/pgpf-$(NAMESPACE).pid; \
+			exit 1; \
+		fi; \
+		PGPASSWORD=$(PG_PASSWORD) psql -h localhost -p $(PG_UPGRADE_LOCAL_PORT) -U admin -d jonline -v ON_ERROR_STOP=1 -f $(DUMP_FILE); \
+		RESTORE_STATUS=$$?; \
+		kill $$(cat /tmp/pgpf-$(NAMESPACE).pid) 2>/dev/null; \
+		rm -f /tmp/pgpf-$(NAMESPACE).pid; \
+		if [ $$RESTORE_STATUS -eq 0 ]; then exit 0; fi; \
+		echo "restore_backend_postgres: attempt $$attempt failed (status $$RESTORE_STATUS)$$([ $$attempt -eq 1 ] && echo ', retrying...' || echo '.')" >&2; \
+	done; \
+	exit 1
+
+# Full Postgres major-version upgrade: dumps the live (old-version) database, stops the app and
+# Postgres, applies the new k8s-postgres-$(K8S_PROVIDER).yaml (new image + new subPath, so the
+# new version initdb's a fresh data directory alongside -- not over -- the old one), restores the
+# dump into it, then brings the app back up. The old version's data directory is left in place on
+# the same PVC as an instant rollback; once you've confirmed the app is healthy on the new
+# version, clean it up by hand with delete_backend_postgres_old_data.
+upgrade_backend_postgres:
+	@echo "== Upgrading Postgres in namespace $(NAMESPACE) (see k8s/k8s-postgres-$(K8S_PROVIDER).yaml for target version) =="
+	$(MAKE) dump_backend_postgres NAMESPACE=$(NAMESPACE) DUMP_FILE=$(PG_BACKUP_DIR)/$(NAMESPACE)-preupgrade.sql
+	$(MAKE) stop_backend NAMESPACE=$(NAMESPACE)
+	$(MAKE) stop_backend_postgres NAMESPACE=$(NAMESPACE)
+	$(MAKE) update_backend_postgres NAMESPACE=$(NAMESPACE)
+	$(MAKE) wait_backend_postgres_ready NAMESPACE=$(NAMESPACE)
+	$(MAKE) restore_backend_postgres NAMESPACE=$(NAMESPACE) DUMP_FILE=$(PG_BACKUP_DIR)/$(NAMESPACE)-preupgrade.sql
+	$(MAKE) start_backend NAMESPACE=$(NAMESPACE)
+	@echo "== Done. Verify the app, then (once confident) run: make delete_backend_postgres_old_data NAMESPACE=$(NAMESPACE) =="
+
+# DESTRUCTIVE, manual-only: permanently deletes the pre-upgrade Postgres data directory left
+# behind (at PVC subPath "postgres") by upgrade_backend_postgres. Only run this per-namespace,
+# once you've confirmed the app is healthy on the new version -- there is no undo.
+delete_backend_postgres_old_data:
+	@echo "This permanently deletes the pre-upgrade Postgres data at postgres-pv-claim:/postgres in namespace $(NAMESPACE)."
+	kubectl exec -n $(NAMESPACE) jonline-postgres-0 -- rm -rf /var/lib/postgresql/data/postgres
 
 # K8s Minio deployment targets (optional if using managed S3/Minio)
 create_backend_minio: deploy_ensure_namespace deploy_ensure_storageclass_retain

--- a/deploys/README.md
+++ b/deploys/README.md
@@ -14,6 +14,7 @@
     - [Example Kubernetes Cluster Setups](#example-kubernetes-cluster-setups)
       - [K8s cluster with multiple Kubernetes LoadBalancers (without a shared ingress)](#k8s-cluster-with-multiple-kubernetes-loadbalancers-without-a-shared-ingress)
       - [K8s cluster with multiple Jonline servers/deployments behind a single shared LoadBalancer](#k8s-cluster-with-multiple-jonline-serversdeployments-behind-a-single-shared-loadbalancer)
+  - [Upgrading your deployed PostgreSQL](#upgrading-your-deployed-postgresql)
 
 Rather than requiring Helm, Ansible, Terraform, or other orchestration layers, Jonline deployment takes a more primitive route. Jonline deployment is built so you can simply maintain one cloned Jonline repo per cluster whose deployments you want to manage. Within your cluster's repo, you'll simply use `make` to deploy:
 
@@ -225,3 +226,12 @@ This is how Jonline was originally deployed, and still is by default for a singl
 #### K8s cluster with multiple Jonline servers/deployments behind a single shared LoadBalancer
 This is what [`deploys/ingress/`](./ingress/README.md) sets up.
 ![System with multiple Kubernetes LoadBalancers](https://github.com/JonLatane/jonline/blob/main/docs/architecture/Traefik_Kubernetes_Deployment.svg)
+
+## Upgrading your deployed PostgreSQL
+The Postgres image tag lives in `k8s/k8s-postgres-$(K8S_PROVIDER).yaml`. For a **minor** version bump (e.g. `17.5` → `17.6`), just edit the tag and run `make update_backend_postgres`. For a **major** version bump (e.g. `14` → `17`), the on-disk data format changes, so don't just `update_backend_postgres` -- use:
+
+```bash
+NAMESPACE=my_namespace make upgrade_backend_postgres
+```
+
+This handles the whole migration: it dumps your current database (via a temporary port-forward, no `kubectl exec` needed), stops the app and the old Postgres, brings up the new version (initdb'd fresh on a new PVC subPath, so the old data directory is never touched), restores the dump into it, then restarts the app. Your old version's data stays on disk as an instant rollback until you're confident in the new one, at which point `make delete_backend_postgres_old_data NAMESPACE=my_namespace` permanently deletes it.

--- a/deploys/k8s/k8s-postgres-digitalocean.yaml
+++ b/deploys/k8s/k8s-postgres-digitalocean.yaml
@@ -1,3 +1,6 @@
+# The PVC (postgres-pv-claim) lives in the sibling k8s-postgres-pvc-$(K8S_PROVIDER).yaml, not
+# here -- see that file for why. create_backend_postgres applies both; update_backend_postgres
+# (which may run often, e.g. via upgrade_backend_postgres) only applies this one.
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,7 +36,7 @@ spec:
         persistentVolumeClaim:
           claimName: postgres-pv-claim
       containers:
-        - image: postgres:14.5-alpine
+        - image: postgres:17.6-alpine
           name: db
           env:
             - name: POSTGRES_USER
@@ -45,21 +48,33 @@ spec:
           ports:
             - containerPort: 5432
               name: db
+          # Without these, kubelet marks the container Ready as soon as its process starts --
+          # not once Postgres is actually accepting connections. On a fresh initdb (e.g. right
+          # after upgrade_backend_postgres swaps in a new major version) that's a ~10s gap, which
+          # raced `kubectl wait --for=condition=ready` ahead of real readiness and made
+          # restore_backend_postgres hit "connection refused" against a Postgres that hadn't
+          # finished starting yet.
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "admin", "-d", "jonline"]
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            timeoutSeconds: 3
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "admin", "-d", "jonline"]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
           volumeMounts:
           - name: pv-data
             mountPath: /var/lib/postgresql/data
-            subPath: postgres
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  labels:
-    app: postgres
-  name: postgres-pv-claim
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-  storageClassName: do-block-storage-retain
+            # Deliberately a *different* subPath than the old pg14.5 data (which lived at
+            # subPath "postgres") -- a Postgres major-version upgrade needs a fresh data
+            # directory (initdb'd by the new image on first boot), and this lets that new
+            # directory live alongside the untouched old one on the same PVC/PV, so the old
+            # data survives as an instant rollback until deliberately removed (see
+            # `delete_backend_postgres_old_data` in ../Makefile).
+            subPath: postgres17

--- a/deploys/k8s/k8s-postgres-pvc-digitalocean.yaml
+++ b/deploys/k8s/k8s-postgres-pvc-digitalocean.yaml
@@ -1,0 +1,20 @@
+# Split out from k8s-postgres-digitalocean.yaml: a PVC's spec (other than resources.requests) is
+# immutable once bound, so re-`apply`-ing it alongside the Service/StatefulSet on every update
+# fails outright if the live PVC's storageClassName ever drifts from what's declared here (as
+# happened when existing PVCs, provisioned on plain "do-block-storage" before the "-retain"
+# StorageClass existed, got left bound rather than recreated). Keeping the PVC in its own file
+# means only create_backend_postgres (a one-time thing per namespace) ever touches it;
+# update_backend_postgres only re-applies the Service/StatefulSet.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: postgres
+  name: postgres-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: do-block-storage-retain


### PR DESCRIPTION
The actual migration is already done, this just makes it easy if someone else may have deployed it (and ensures new users default to Postgres 17.6).